### PR TITLE
[TRNT-4317] Pin GHA to SHA instead of tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer


### PR DESCRIPTION
# Description

As security incidents are popping up constantly, it is a good practice to pin the GHA to a specific SHA instead of tags, in case the GHA repository gets compromised. This PR replaces all the versions with the specific SHA.

Related # TRNT-4317


```
==> Summary
    Total uses: references found : 5
    Already pinned (SHA)         : 4
    Pinned in this run           : 1
    Resolved from cache          : 1
    Hardcoded overrides applied  : 0
    Private/inaccessible (logged): 0
    Failed to resolve            : 0
```

## How was this tested?

N/A

