### PR TITLE
[TRNT-4358] Add license headers

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 name: Docker
 
 # This workflow uses actions that are not certified by GitHub.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,6 +39,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
+      # Run SkyWalking Eyes to check license headers.
+      - uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
+        name: Check license Headers
+
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+header:
+  comment: on-failure
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: SUSE LLC
+    software-name: trento-barbecue
+    content: |
+      SPDX-FileCopyrightText: SUSE LLC
+      SPDX-License-Identifier: Apache-2.0
+  paths-ignore:
+    - "**/etc/**"
+    - "**/usr/**"
+    - ".github/dependabot.yml"
+    - "LICENSE"

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 SUSE LLC
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -199,4 +199,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-

--- a/hana_node01/Dockerfile
+++ b/hana_node01/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # Fetch and build the agent
 # The agent is built in a separate stage to avoid copying the whole repository into the final image
 FROM golang as agent-builder

--- a/hana_node01/init.sh
+++ b/hana_node01/init.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+
 set -m
 
 # Start the first process

--- a/hana_node02/Dockerfile
+++ b/hana_node02/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # Fetch and build the agent
 # The agent is built in a separate stage to avoid copying the whole repository into the final image
 FROM golang as agent-builder


### PR DESCRIPTION
# Description

In an attempt to follow the REUSE Specification (supported by the Linux Foundation) for managing licence information, this PR adds the recommended `SPDX-FileCopyrightText` and `SPDX-License-Identifier` headers.

Besides, a new linter is added for the CI to check the license headers. 

It also updates the text of the `LICENSE` file to comply with the licensing terms. We need to provide a verbatim copy of the license text. Therefore, we simply copied the official text available at https://www.apache.org/licenses/LICENSE-2.0.txt into our repository.

_Note: this PR does **not** affect the existing license of the project. It is a mere formality._

Related # TRNT-4358

## How was this tested?

License linter.